### PR TITLE
Bug fix: update session management for EHLO command compliance

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -238,7 +238,7 @@ func (c *Conn) handleGreet(enhanced bool, arg string) {
 		sess, err := c.server.Backend.NewSession(c)
 		if err != nil {
 			c.helo = ""
-			c.writeError(451, EnhancedCode{4, 0, 0}, err)
+			c.writeResponse(451, EnhancedCode{4, 0, 0}, err.Error())
 			return
 		}
 

--- a/conn.go
+++ b/conn.go
@@ -230,7 +230,7 @@ func (c *Conn) handleGreet(enhanced bool, arg string) {
 	c.helo = domain
 
 	// RFC 5321: "An EHLO command MAY be issued by a client later in the session"
-	if c.session != nil {
+	if c.Session() != nil {
 		// RFC 5321: "... the SMTP server MUST clear all buffers
 		// and reset the state exactly as if a RSET command has been issued."
 		c.reset()

--- a/conn.go
+++ b/conn.go
@@ -229,16 +229,21 @@ func (c *Conn) handleGreet(enhanced bool, arg string) {
 	}
 	c.helo = domain
 
-	sess, err := c.server.Backend.NewSession(c)
-	if err != nil {
-		if smtpErr, ok := err.(*SMTPError); ok {
-			c.writeResponse(smtpErr.Code, smtpErr.EnhancedCode, smtpErr.Message)
+	// RFC 5321: "An EHLO command MAY be issued by a client later in the session"
+	if c.session != nil {
+		// RFC 5321: "... the SMTP server MUST clear all buffers
+		// and reset the state exactly as if a RSET command has been issued."
+		c.reset()
+	} else {
+		sess, err := c.server.Backend.NewSession(c)
+		if err != nil {
+			c.helo = ""
+			c.writeError(451, EnhancedCode{4, 0, 0}, err)
 			return
 		}
-		c.writeResponse(451, EnhancedCode{4, 0, 0}, err.Error())
-		return
+
+		c.setSession(sess)
 	}
-	c.setSession(sess)
 
 	if !enhanced {
 		c.writeResponse(250, EnhancedCode{2, 0, 0}, fmt.Sprintf("Hello %s", domain))


### PR DESCRIPTION
Refactor session handling to comply with RFC 5321 regarding EHLO command.

Only if session == nil should we create a new session. Otherwise we should simply reset the mail state.

This fix comes from upstream (emersion/go-smtp)